### PR TITLE
Support to validate kernel version for centos

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 
 	"github.com/coreos/go-semver/semver"
+	"regexp"
 )
 
 type Locker interface {
@@ -28,10 +29,16 @@ func newLocker() Locker {
 
 func validateKernel(bytes []byte) bool {
 	kernel := strings.Split(strings.TrimRight(string(bytes), "\n"), " ")
-	if kernel[0] == "Linux" && !semver.New(kernel[1]).LessThan(*semver.New("3.15.0")) {
+	nk := normalizeKernelVersion(kernel[1])
+	if kernel[0] == "Linux" && !semver.New(nk).LessThan(*semver.New("3.15.0")) {
 		return true
 	}
 	return false
+}
+
+func normalizeKernelVersion(v string) string {
+	re := regexp.MustCompile(".elrepo.x86_64|.el7.x86_64")
+	return re.ReplaceAllString(v, "")
 }
 
 // Only Linux and kernel version 3.15 or later.

--- a/lock.go
+++ b/lock.go
@@ -20,14 +20,18 @@ func newLocker() Locker {
 	if err != nil {
 		return Flock{}
 	}
-	kernel := strings.Split(strings.TrimRight(string(bytes), "\n"), " ")
-	if len(kernel) != 2 {
-		return Flock{}
-	}
-	if kernel[0] == "Linux" && !semver.New(kernel[1]).LessThan(*semver.New("3.15.0")) {
+	if validateKernel(bytes) {
 		return Fcntl{}
 	}
 	return Flock{}
+}
+
+func validateKernel(bytes []byte) bool {
+	kernel := strings.Split(strings.TrimRight(string(bytes), "\n"), " ")
+	if kernel[0] == "Linux" && !semver.New(kernel[1]).LessThan(*semver.New("3.15.0")) {
+		return true
+	}
+	return false
 }
 
 // Only Linux and kernel version 3.15 or later.

--- a/lock_test.go
+++ b/lock_test.go
@@ -1,0 +1,27 @@
+package gannoy
+
+import (
+	"testing"
+)
+
+func TestVersionCheckSemverKernel(t *testing.T) {
+	bytes := []byte("Linux 4.12.2-1")
+	if validateKernel(bytes) != true {
+		t.Errorf("Kernel Version is not less than 3.15.0")
+	}
+}
+
+func TestVersionCheckElrepoKernel(t *testing.T) {
+	bytes := []byte("Linux 4.12.2-1.el7.elrepo.x86_64")
+	if validateKernel(bytes) != true {
+		t.Errorf("Kernel Version is not less than 3.15.0")
+	}
+}
+
+func TestVersionCheckKernel(t *testing.T) {
+	bytes := []byte("Linux 3.10.0-327.36.1.el7.x86_64")
+	if validateKernel(bytes) != false {
+		t.Errorf("Kernel Version is less than 3.15.0")
+	}
+}
+


### PR DESCRIPTION
Occur following error when execute gannoy-db on CentOS.
`uname -sr` return `Linux 4.12.2-1.el7.elrepo.x86_64` on CentOS, this is not a valid semver identifier.

```
panic: failed to validate pre-release: 1.el7.elrepo.x86_64 is not a valid semver identifier

goroutine 7 [running]:
github.com/coreos/go-semver/semver.Must(0x0, 0xa26360, 0xc4200f67e0, 0xa26360)
        /root/go/src/github.com/coreos/go-semver/semver/semver.go:65 +0x54
github.com/coreos/go-semver/semver.New(0xc420011ec6, 0x1a, 0x8669d0)
        /root/go/src/github.com/coreos/go-semver/semver/semver.go:49 +0x57
github.com/monochromegane/gannoy.newLocker(0x7d4d40, 0x1)
        /root/go/src/github.com/monochromegane/gannoy/lock.go:27 +0x1cc
github.com/monochromegane/gannoy.newFile(0xc4200b1620, 0x1a, 0x1, 0x800, 0x3, 0xc4200b1560)
        /root/go/src/github.com/monochromegane/gannoy/file.go:42 +0xde
github.com/monochromegane/gannoy.newNodes(0xc4200b1620, 0x1a, 0x1, 0x800, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /root/go/src/github.com/monochromegane/gannoy/node.go:12 +0xa1
github.com/monochromegane/gannoy.NewGannoyIndex(0xc4200b1560, 0x1a, 0xa2c360, 0xa76e08, 0xa2a4a0, 0xa76e08, 0x0, 0x0, 0x0, 0x0, ...)
        /root/go/src/github.com/monochromegane/gannoy/gannoy.go:44 +0x16e
main.gannoyIndexInitializer(0xc42005e5a0, 0xc42005e600, 0xc42005e660)
        /root/go/src/github.com/monochromegane/gannoy/cmd/gannoy-db/main.go:305 +0x159
created by main.main
        /root/go/src/github.com/monochromegane/gannoy/cmd/gannoy-db/main.go:135 +0x7ba
```

So, how about to normalize kernel version before validate?